### PR TITLE
Use nfsexports for NFS export management

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -42,6 +42,10 @@
 			"Rev": "197e8d3cf42199cfd53cd775deb37f3637234635"
 		},
 		{
+			"ImportPath": "github.com/johanneswuerbach/nfsexports",
+			"Rev": "a9068f3f0daa39616953aec11c3eb1209ebc4086"
+		},
+		{
 			"ImportPath": "github.com/kr/fs",
 			"Rev": "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
 		},

--- a/Godeps/_workspace/src/github.com/johanneswuerbach/nfsexports/.travis.yml
+++ b/Godeps/_workspace/src/github.com/johanneswuerbach/nfsexports/.travis.yml
@@ -1,0 +1,10 @@
+os: osx
+language: go
+go:
+  - 1.5.1
+
+before_script:
+  - sudo nfsd status
+  - sudo touch /etc/exports # Auto-starts nfsd on OS X
+  - sleep 5
+  - sudo nfsd status

--- a/Godeps/_workspace/src/github.com/johanneswuerbach/nfsexports/README.md
+++ b/Godeps/_workspace/src/github.com/johanneswuerbach/nfsexports/README.md
@@ -1,0 +1,34 @@
+# nfsexports [![Build Status](https://travis-ci.org/johanneswuerbach/nfsexports.svg?branch=master)](https://travis-ci.org/johanneswuerbach/nfsexports)
+
+Go util to manage NFS exports `/etc/exports`.
+
+## Features
+
+* Add and remove exports
+* Verify the added export is valid, before updating
+* Auto-creates missing exports file, which auto starts nfsd on OS X
+* Handles missing line breaks
+
+```go
+package main
+
+import (
+    "github.com/johanneswuerbach/nfsexports"
+)
+
+func main() {
+  newExports, err := nfsexports.Add("", "myExport", "/Users 192.168.64.16 -alldirs -maproot=root")
+  if err != nil {
+      panic(err)
+  }
+
+  newExports, err := nfsexports.Remove("", "myExport")
+  if err != nil {
+      panic(err)
+  }
+
+  if err = nfsexports.ReloadDaemon(); err != nil {
+      panic(err)
+  }
+}
+```

--- a/Godeps/_workspace/src/github.com/johanneswuerbach/nfsexports/nfsexports.go
+++ b/Godeps/_workspace/src/github.com/johanneswuerbach/nfsexports/nfsexports.go
@@ -1,0 +1,124 @@
+package nfsexports
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+const (
+	defaultExportsFile = "/etc/exports"
+)
+
+// Add export, if exportsFile is an empty string /etc/exports is used
+func Add(exportsFile string, identifier string, export string) ([]byte, error) {
+	if exportsFile == "" {
+		exportsFile = defaultExportsFile
+	}
+
+	exports, err := ioutil.ReadFile(exportsFile)
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			exports = []byte{}
+		} else {
+			return nil, err
+		}
+	}
+
+	if containsExport(exports, identifier) {
+		return exports, nil
+	}
+
+	newExports := exports
+	if len(newExports) > 0 && !bytes.HasSuffix(exports, []byte("\n")) {
+		newExports = append(newExports, '\n')
+	}
+
+	newExports = append(newExports, []byte(exportEntry(identifier, export))...)
+
+	if err := verifyNewExports(newExports); err != nil {
+		return nil, err
+	}
+
+	if err := ioutil.WriteFile(exportsFile, newExports, 0644); err != nil {
+		return nil, err
+	}
+
+	return newExports, nil
+}
+
+// Remove export, if exportsFile is an empty string /etc/exports is used
+func Remove(exportsFile string, identifier string) ([]byte, error) {
+	if exportsFile == "" {
+		exportsFile = defaultExportsFile
+	}
+
+	exports, err := ioutil.ReadFile(exportsFile)
+	if err != nil {
+		return nil, err
+	}
+
+	beginMark := []byte(fmt.Sprintf("# BEGIN: %s", identifier))
+	endMark := []byte(fmt.Sprintf("# END: %s\n", identifier))
+
+	begin := bytes.Index(exports, beginMark)
+	end := bytes.Index(exports, endMark)
+
+	if begin == -1 || end == -1 {
+		return nil, fmt.Errorf("Couldn't not find export %s in %s", identifier, exportsFile)
+	}
+
+	newExports := append(exports[:begin], exports[end+len(endMark):]...)
+	newExports = append(bytes.TrimSpace(newExports), '\n')
+
+	if err := ioutil.WriteFile(exportsFile, newExports, 0644); err != nil {
+		return nil, err
+	}
+
+	return newExports, nil
+}
+
+// ReloadDaemon reload NFS daemon
+func ReloadDaemon() error {
+	cmd := exec.Command("sudo", "nfsd", "update")
+	cmd.Stderr = &bytes.Buffer{}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Reloading nfds failed: %s\n%s", err.Error(), cmd.Stderr)
+	}
+
+	return nil
+}
+
+func containsExport(exports []byte, identifier string) bool {
+	return bytes.Contains(exports, []byte(fmt.Sprintf("# BEGIN: %s\n", identifier)))
+}
+
+func exportEntry(identifier string, export string) string {
+	return fmt.Sprintf("# BEGIN: %s\n%s\n# END: %s\n", identifier, export, identifier)
+}
+
+func verifyNewExports(newExports []byte) error {
+	tmpFile, err := ioutil.TempFile("", "exports")
+	if err != nil {
+		return err
+	}
+	defer tmpFile.Close()
+
+	if _, err := tmpFile.Write(newExports); err != nil {
+		return err
+	}
+	tmpFile.Close()
+
+	cmd := exec.Command("nfsd", "-F", tmpFile.Name(), "checkexports")
+	cmd.Stderr = &bytes.Buffer{}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Export verification failed:\n%s\n%s", cmd.Stderr, err.Error())
+	}
+
+	return nil
+}


### PR DESCRIPTION
While working on https://github.com/zchee/docker-machine-driver-xhyve, I wrote a small util to manage NFS exports https://travis-ci.org/johanneswuerbach/nfsexports.

It supports:
- Verifying that the resulting exports is correct
- Correct line break merging
- Allows adding and removed with a unique id

Contributions definitely welcome. WDYT?
