### PR TITLE
remove cloud-config header from fuze config

### DIFF
--- a/components/common/assets/static/target/coreos/corectl.ignition.yaml
+++ b/components/common/assets/static/target/coreos/corectl.ignition.yaml
@@ -1,5 +1,3 @@
-#cloud-config
-
 ---
 {{ if index "SSHAuthorizedKeys" }}
 passwd:


### PR DESCRIPTION
This configuration is not a cloud-config, so there is no need for this
header.

Signed-off-by: Alex Crawford <alex.crawford@coreos.com>