### PR TITLE
remove update-engine and locksmith configuration

### DIFF
--- a/components/common/assets/static/target/coreos/corectl.ignition.yaml
+++ b/components/common/assets/static/target/coreos/corectl.ignition.yaml
@@ -85,10 +85,6 @@ networkd:
 
 systemd:
   units:
-  - name: update-engine.service
-    enable: false
-  - name: locksmithd.service
-    enable: false
   - name: corectl-set-hostname.service
     enable: true
     contents: |


### PR DESCRIPTION
These two services will not start when CoreOS Linux is PXE-booted, so
there is no need to disable them. Additionally, using "enable: false"
doesn't actually have any effect.

Signed-off-by: Alex Crawford <alex.crawford@coreos.com>