### PR TITLE
add corectl-metadata.service

### DIFF
--- a/components/common/assets/static/target/coreos/corectl.ignition.yaml
+++ b/components/common/assets/static/target/coreos/corectl.ignition.yaml
@@ -116,6 +116,14 @@ systemd:
         ExecStart=/home/core/bin/find-ip4.sh eth0 /etc/environment COREOS_PUBLIC_IPV4
       [Install]
         RequiredBy=system-config.target
+  - name: corectl-metadata.service
+    contents: |
+      [Unit]
+        Description=Populate machine metadata
+      [Service]
+        Type=oneshot
+        StandardOutput=journal+console
+        ExecStart=/home/core/bin/find-ip4.sh eth0 /run/metadata/corectl CORECTL_IPV4_ETH0
   - name: phone-home.service
     enable: true
     contents: |


### PR DESCRIPTION
Just like coreos-metadata, this service populates a file
(/run/metadata/corectl) with information about the system (just the IP
address in this case). This file is intended to be sourced into systemd
services via the EnvironmentFile directive, allowing services to use
dynamic configuration. Since this service is not started by default,
dependent services will need to use Require and After to ensure that
they run only once corectl-metadata.service has completed.

Signed-off-by: Alex Crawford <alex.crawford@coreos.com>