### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/components/server/etcd.go
+++ b/components/server/etcd.go
@@ -103,7 +103,7 @@ func (d *ServerContext) NewEtcd(clientURLStrs,
 	return nil
 }
 
-// Starts starts the etcd server and listening for client connections
+// Start starts starts the etcd server and listening for client connections
 func (e *EtcdServer) Start() (err error) {
 	e.EtcdServer, err = etcdserver.NewServer(e.config)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?